### PR TITLE
Update Audi A1: fix second generation start year and add references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
-# Model make
+# Audi A1
 
+This repository contains signal set configurations for the Audi A1, organized by model year and version. The files are structured to allow for easy differentiation between model generations and other vehicle parameters, ensuring accurate signal mapping for each version of the Audi A1.
+
+## Contributing
+
+Contributions are welcome! If you would like to add support for additional model years or other configurations, please open an issue or submit a pull request.
+
+1. Fork the repository
+2. Create a new branch for your changes
+3. Commit your changes and open a pull request with a detailed description
+
+## Issues
+
+If you encounter any issues or would like to discuss improvements, please feel free to open an issue. We encourage collaboration and appreciate feedback to make the repository as accurate and useful as possible.

--- a/generations.yaml
+++ b/generations.yaml
@@ -1,3 +1,6 @@
+references:
+  - "https://en.wikipedia.org/wiki/Audi_A1"
+
 generations:
   - name: "First Generation (8X)"
     start_year: 2010
@@ -5,6 +8,6 @@ generations:
     description: "The first generation Audi A1 was a premium supermini based on the Volkswagen Group PQ25 platform. Available as a three-door hatchback and later as a five-door 'Sportback', it featured distinctive design elements including the single-frame grille and optional contrasting roof colors. Engine options ranged from 1.0L to 1.4L TFSI petrol and 1.6L TDI diesel units. The sportier S1 variant offered a 2.0L turbocharged engine with quattro all-wheel drive. The A1 brought Audi's premium quality and technology to the subcompact segment."
 
   - name: "Second Generation (GB)"
-    start_year: 2018
+    start_year: 2019
     end_year: null
     description: "Built on the MQB A0 platform, the second-generation A1 grew in size and is offered exclusively as a five-door Sportback. It features a more aggressive design with styling cues inspired by the original Quattro rally car. The interior received Audi's latest technology including the Virtual Cockpit digital instrument display and improved infotainment systems. Engine options include 1.0L, 1.5L, and 2.0L TFSI petrol engines, with no diesel options offered. This generation focuses more on connectivity, technology, and sportier design while maintaining premium quality in the small car segment."


### PR DESCRIPTION
- Fixed: Second generation start year corrected from 2018 to 2019 per Wikipedia model year
- Added: Wikipedia reference to generations.yaml
- Updated: README.md with standard template

Per Wikipedia: Second generation was released in 2019 (model year), though production started in October 2018. Using model years: first generation 2010-2018, second generation 2019-present (production through 2026).

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
